### PR TITLE
1: Display empty sudoku puzzle when user launches app (branch to merge)

### DIFF
--- a/ElementarySudokuSolver/ElementarySudokuSolver.xcodeproj/project.pbxproj
+++ b/ElementarySudokuSolver/ElementarySudokuSolver.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		041528BC267519F20048DE48 /* NonetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041528BB267519F20048DE48 /* NonetView.swift */; };
+		041528C426751A5C0048DE48 /* TripletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 041528C326751A5C0048DE48 /* TripletView.swift */; };
 		0444E93C266943C400A080E5 /* ElementarySudokuSolverApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0444E93B266943C400A080E5 /* ElementarySudokuSolverApp.swift */; };
 		0444E93E266943C400A080E5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0444E93D266943C400A080E5 /* ContentView.swift */; };
 		0444E940266943C500A080E5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0444E93F266943C500A080E5 /* Assets.xcassets */; };
@@ -33,6 +35,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		041528BB267519F20048DE48 /* NonetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonetView.swift; sourceTree = "<group>"; };
+		041528C326751A5C0048DE48 /* TripletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripletView.swift; sourceTree = "<group>"; };
 		0444E938266943C400A080E5 /* ElementarySudokuSolver.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ElementarySudokuSolver.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0444E93B266943C400A080E5 /* ElementarySudokuSolverApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementarySudokuSolverApp.swift; sourceTree = "<group>"; };
 		0444E93D266943C400A080E5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -97,6 +101,8 @@
 			children = (
 				0444E93B266943C400A080E5 /* ElementarySudokuSolverApp.swift */,
 				0444E93D266943C400A080E5 /* ContentView.swift */,
+				041528BB267519F20048DE48 /* NonetView.swift */,
+				041528C326751A5C0048DE48 /* TripletView.swift */,
 				0444E93F266943C500A080E5 /* Assets.xcassets */,
 				0444E944266943C500A080E5 /* Info.plist */,
 				0444E941266943C500A080E5 /* Preview Content */,
@@ -260,7 +266,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0444E93E266943C400A080E5 /* ContentView.swift in Sources */,
+				041528BC267519F20048DE48 /* NonetView.swift in Sources */,
 				0444E93C266943C400A080E5 /* ElementarySudokuSolverApp.swift in Sources */,
+				041528C426751A5C0048DE48 /* TripletView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -44,9 +44,10 @@ struct NonetView: View {
     let data = (1...9).map { "\($0)" }
     
     let columns = [
-        GridItem(.flexible(), spacing: 0),
-        GridItem(.flexible(), spacing: 0),
-        GridItem(.flexible(), spacing: 0)
+        // 3 identical GridItems because I want 3 identical columns
+        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0),
+        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0),
+        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0)
     ]
     
     var body: some View {
@@ -56,12 +57,13 @@ struct NonetView: View {
             spacing: 0
         ) {
             ForEach(data, id: \.self) { item in
-                HStack {
+                HStack(spacing: 0) {
                     Spacer()
                     Text(item)
+                        //.font(.system(size: 4))
+                        .border(Color.green, width: 1)
                     Spacer()
                 }
-                .padding()
                 .border(Color.blue, width: 1)
             }
         }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct ContentView: View {
     
     var body: some View {
-        // Text("Keep trying!!")
         
         GeometryReader { geometry in
             
@@ -35,32 +34,6 @@ struct ContentView: View {
                 }
             }.border(Color.black, width: 2)
             
-//            HStack {
-//                VStack(spacing: 0)  {
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                }
-//                VStack(spacing: 0)  {
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                }
-//                VStack(spacing: 0)  {
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                    NonetView3(containerLimit: shorterLength * 0.33)
-//                        .frame(height: shorterLength * 0.33)
-//                }
-//            }
         }
     }
 }
@@ -127,19 +100,16 @@ struct TripletView: View {
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                //.background(Color.yellow)
                 .border(Color.black, width: 1)
             Text(" ")
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                //.background(Color.orange)
                 .border(Color.black, width: 1)
             Text(" ")
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                //.background(Color.green)
                 .border(Color.black, width: 1)
         }
     }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -8,9 +8,34 @@
 import SwiftUI
 
 struct ContentView: View {
+    
+    let data = (1...9).map { "Item \($0)" }
+    
+    let columns = [
+        GridItem(.flexible(), spacing: 0),
+        GridItem(.flexible(), spacing: 0),
+        GridItem(.flexible(), spacing: 0)
+    ]
+    
     var body: some View {
         Text("Hello, world!")
             .padding()
+        LazyVGrid(
+            columns: columns,
+            alignment: .center,
+            spacing: 0
+        ) {
+            ForEach(data, id: \.self) { item in
+                HStack {
+                    Spacer()
+                    Text(item)
+                    Spacer()
+                }
+                .padding()
+                .border(Color.blue, width: 1)
+            }
+        }
+        .border(Color.red, width: 3)
     }
 }
 

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -13,8 +13,23 @@ struct ContentView: View {
         Text("Keep trying!!")
         
         GeometryReader { geometry in
-            
-            NonetView()
+            HStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    NonetView()
+                    NonetView()
+                    NonetView()
+                }.border(Color.blue, width: 4)
+                VStack(spacing: 0) {
+                    NonetView()
+                    NonetView()
+                    NonetView()
+                }
+                VStack(spacing: 0) {
+                    NonetView().border(Color.blue, width: 2)
+                    NonetView()
+                    NonetView()
+                }
+            }
             
 //            HStack {
 //                VStack(spacing: 0)  {
@@ -59,6 +74,15 @@ struct ContentView_Previews: PreviewProvider {
             NonetView()
                 .frame(width: 100, height: 300)
                 .background(Color.blue)
+        }
+        VStack {
+            Text("This is not what I want")
+            VStack(spacing: 0) {
+                NonetView()
+                    .border(Color.blue, width: 2)
+                NonetView()
+                NonetView()
+            }.frame(width: 100)
         }
     }
 }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -9,6 +9,20 @@ import SwiftUI
 
 struct ContentView: View {
     
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+        NonetView()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
+
+struct NonetView: View {
     let data = (1...9).map { "Item \($0)" }
     
     let columns = [
@@ -18,8 +32,6 @@ struct ContentView: View {
     ]
     
     var body: some View {
-        Text("Hello, world!")
-            .padding()
         LazyVGrid(
             columns: columns,
             alignment: .center,
@@ -36,11 +48,5 @@ struct ContentView: View {
             }
         }
         .border(Color.red, width: 3)
-    }
-}
-
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
     }
 }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -13,21 +13,25 @@ struct ContentView: View {
         Text("Keep trying!!")
         
         GeometryReader { geometry in
+            
+            let shorterSide = geometry.size.width < geometry.size.height ? geometry.size.width : geometry.size.height
+            let nonetSideLength = shorterSide / 3
+            
             HStack(spacing: 0) {
                 VStack(spacing: 0) {
-                    NonetView()
-                    NonetView()
-                    NonetView()
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                 }.border(Color.blue, width: 4)
                 VStack(spacing: 0) {
-                    NonetView()
-                    NonetView()
-                    NonetView()
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                 }
                 VStack(spacing: 0) {
-                    NonetView().border(Color.blue, width: 2)
-                    NonetView()
-                    NonetView()
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength).border(Color.blue, width: 2)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                 }
             }
             

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -8,29 +8,46 @@
 import SwiftUI
 
 struct ContentView: View {
+    let data = (1...81).map { "\($0)" }
     
-    let data = (1...9).map { "Item \($0)" }
-    
-    let columns = [
-        GridItem(.flexible(), spacing: 0),
-        GridItem(.flexible(), spacing: 0),
-        GridItem(.flexible(), spacing: 0)
+    let rows = [
+        // 9 identical GridItems because I want 3 identical rows
+        // because these are rows, the minimum is the minimum height
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0)
     ]
     
     var body: some View {
-        Text("Hello, world!")
+        Text("Triplet View")
             .padding()
-        LazyVGrid(
-            columns: columns,
+        LazyHGrid(
+            rows: rows,
             alignment: .center,
             spacing: 0
         ) {
             ForEach(data, id: \.self) { item in
-                NonetView()
-                .border(Color.yellow, width: 1)
+                HStack {
+                    Spacer()
+                    VStack(spacing: 0) {
+                        Spacer()
+                        Text(item)
+                            .border(Color.green, width: 1)
+                        Spacer()
+                    }
+                    Spacer()
+                }
+                .border(Color.blue, width: 1)
             }
         }
-        .border(Color.orange, width: 3)
+        .border(Color.yellow, width: 3)
+        
     }
 }
 
@@ -41,13 +58,40 @@ struct ContentView_Previews: PreviewProvider {
 }
 
 struct NonetView: View {
-    let data = (1...9).map { "\($0)" }
+    let data = (1...3).map { "Row \($0)" }
+    
+    let rows = [
+        // 3 identical GridItems because I want 3 identical rows
+        // because these are rows, the minimum is the minimum height
+        GridItem(.flexible(minimum: 100), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 100), spacing: 0)
+    ]
+    
+    var body: some View {
+        LazyHGrid(
+            rows: rows,
+            alignment: .center,
+            spacing: 0
+        ) {
+            ForEach(data, id: \.self) { item in
+                TripletView()
+                    .padding(0)
+            }
+        }
+        .border(Color.yellow, width: 3)
+    }
+}
+
+struct TripletView: View {
+    let data = (1...3).map { "\($0)" }
     
     let columns = [
         // 3 identical GridItems because I want 3 identical columns
-        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0),
-        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0),
-        GridItem(.adaptive(minimum: 35, maximum: 100), spacing: 0)
+        // because these are columns, the minimum is the minimum width
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0),
+        GridItem(.flexible(minimum: 35), spacing: 0)
     ]
     
     var body: some View {
@@ -57,11 +101,14 @@ struct NonetView: View {
             spacing: 0
         ) {
             ForEach(data, id: \.self) { item in
-                HStack(spacing: 0) {
+                HStack {
                     Spacer()
-                    Text(item)
-                        //.font(.system(size: 4))
-                        .border(Color.green, width: 1)
+                    VStack(spacing: 0) {
+                        Spacer()
+                        Text(item)
+                            .border(Color.green, width: 1)
+                        Spacer()
+                    }
                     Spacer()
                 }
                 .border(Color.blue, width: 1)

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -11,36 +11,37 @@ struct ContentView: View {
     
     var body: some View {
         Text("Keep trying!!")
+        
         GeometryReader { geometry in
             
-            let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
+            NonetView()
             
-            HStack {
-                VStack(spacing: 0)  {
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                }
-                VStack(spacing: 0)  {
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                }
-                VStack(spacing: 0)  {
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                    NonetView3(containerLimit: shorterLength * 0.33)
-                        .frame(height: shorterLength * 0.33)
-                }
-            }
+//            HStack {
+//                VStack(spacing: 0)  {
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                }
+//                VStack(spacing: 0)  {
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                }
+//                VStack(spacing: 0)  {
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                    NonetView3(containerLimit: shorterLength * 0.33)
+//                        .frame(height: shorterLength * 0.33)
+//                }
+//            }
         }
         
     }
@@ -52,136 +53,56 @@ struct ContentView_Previews: PreviewProvider {
     }
 }
 
-struct NonetView3: View {
-    
-    let containerLimit: CGFloat
+/*
+ A NonetView is a square made up of 9 squares in a 3 x 3 formation. It fills it's containing view, but does not overflow it ever.
+ */
+struct NonetView: View {
     
     var body: some View {
         GeometryReader { geometry in
             
-            //let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
-            
             VStack(spacing: 0) {
-                TripletView2(containerLimit: containerLimit)
-                    .frame(height: containerLimit * 0.33)
-                TripletView2(containerLimit: containerLimit)
-                    .frame(height: containerLimit * 0.34)
-                TripletView2(containerLimit: containerLimit)
-                    .frame(height: containerLimit * 0.33)
+                TripletView(containerSize: geometry.size)
+                TripletView(containerSize: geometry.size)
+                TripletView(containerSize: geometry.size)
             }
             .border(Color.red, width: 4)
         }
     }
 }
 
-    
-struct TripletView2: View {
-    
-    let containerLimit: CGFloat
-    
-    var body: some View {
-            
-            HStack(spacing: 0) {
-                Text("1")
-                    .font(.largeTitle)
-                    .foregroundColor(.black)
-                    .frame(width: containerLimit * 0.33, height: containerLimit * 0.33)
-                    .background(Color.yellow)
-                    .border(Color.black, width: 1)
-                Text("2")
-                    .font(.largeTitle)
-                    .foregroundColor(.black)
-                    .frame(width: containerLimit * 0.34, height: containerLimit * 0.33)
-                    .background(Color.orange)
-                    .border(Color.black, width: 1)
-                Text("3")
-                    .font(.largeTitle)
-                    .foregroundColor(.black)
-                    .frame(width:  containerLimit * 0.33, height: containerLimit * 0.33)
-                    .background(Color.green)
-                    .border(Color.black, width: 1)
-            }
-    }
-}
-
-struct NonetView2: View {
-    let columnData = (1...3).map { "c\($0)" }
-    let rowData = (1...3).map { "r\($0)" }
-    
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(columnData, id: \.self) { item in
-                VStack(spacing: 0) {
-                    ForEach(rowData, id: \.self) { item in
-                        Text("2")
-                            //.padding()
-                        Divider()
-                    }
-                }
-                Divider()
-            }
-        }
-        .border(Color.yellow, width: 2)
-    }
-}
-
-struct NonetView: View {
-    let data = (1...3).map { "Row \($0)" }
-    
-    let rows = [
-        // 3 identical GridItems because I want 3 identical rows
-        // because these are rows, the minimum is the minimum height
-        GridItem(.flexible(minimum: 100), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 100), spacing: 0)
-    ]
-    
-    var body: some View {
-        LazyHGrid(
-            rows: rows,
-            alignment: .center,
-            spacing: 0
-        ) {
-            ForEach(data, id: \.self) { item in
-                TripletView()
-                    .padding(0)
-            }
-        }
-        .border(Color.yellow, width: 3)
-    }
-}
-
+/*
+ A TripletView is a 1 x 3 grid. It is a single row of 3 squares. It will expand to fill it's containing view, but will always
+ be comprised of 3 squares, not rectangles.
+ */
 struct TripletView: View {
-    let data = (1...3).map { "\($0)" }
     
-    let columns = [
-        // 3 identical GridItems because I want 3 identical columns
-        // because these are columns, the minimum is the minimum width
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0)
-    ]
+    let containerSize: CGSize
     
     var body: some View {
-        LazyVGrid(
-            columns: columns,
-            alignment: .center,
-            spacing: 0
-        ) {
-            ForEach(data, id: \.self) { item in
-                HStack {
-                    Spacer()
-                    VStack(spacing: 0) {
-                        Spacer()
-                        Text(item)
-                            .border(Color.green, width: 1)
-                        Spacer()
-                    }
-                    Spacer()
-                }
-                .border(Color.blue, width: 1)
-            }
+        
+        let containerLimit = containerSize.width < containerSize.height ? containerSize.width : containerSize.height
+        let sqSide: CGFloat = containerLimit / 3
+            
+        HStack(spacing: 0) {
+            Text("1")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .background(Color.yellow)
+                .border(Color.black, width: 1)
+            Text("2")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .background(Color.orange)
+                .border(Color.black, width: 1)
+            Text("3")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .background(Color.green)
+                .border(Color.black, width: 1)
         }
-        .border(Color.red, width: 3)
     }
 }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ContentView: View {
     
     var body: some View {
-        Text("Keep trying!!")
+        // Text("Keep trying!!")
         
         GeometryReader { geometry in
             
@@ -22,18 +22,18 @@ struct ContentView: View {
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
-                }.border(Color.blue, width: 4)
+                }
                 VStack(spacing: 0) {
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                 }
                 VStack(spacing: 0) {
-                    NonetView().frame(width: nonetSideLength, height: nonetSideLength).border(Color.blue, width: 2)
+                    NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                     NonetView().frame(width: nonetSideLength, height: nonetSideLength)
                 }
-            }
+            }.border(Color.black, width: 2)
             
 //            HStack {
 //                VStack(spacing: 0)  {
@@ -104,7 +104,7 @@ struct NonetView: View {
                 TripletView(containerSize: geometry.size)
                 TripletView(containerSize: geometry.size)
             }
-            .border(Color.red, width: 4)
+            .border(Color.black, width: 2)
         }
     }
 }
@@ -123,23 +123,23 @@ struct TripletView: View {
         let sqSide: CGFloat = containerLimit / 3
             
         HStack(spacing: 0) {
-            Text("1")
+            Text(" ")
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                .background(Color.yellow)
+                //.background(Color.yellow)
                 .border(Color.black, width: 1)
-            Text("2")
+            Text(" ")
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                .background(Color.orange)
+                //.background(Color.orange)
                 .border(Color.black, width: 1)
-            Text("3")
+            Text(" ")
                 .font(.largeTitle)
                 .foregroundColor(.black)
                 .frame(width: sqSide, height: sqSide)
-                .background(Color.green)
+                //.background(Color.green)
                 .border(Color.black, width: 1)
         }
     }

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -8,45 +8,30 @@
 import SwiftUI
 
 struct ContentView: View {
-    let data = (1...81).map { "\($0)" }
-    
-    let rows = [
-        // 9 identical GridItems because I want 3 identical rows
-        // because these are rows, the minimum is the minimum height
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0),
-        GridItem(.flexible(minimum: 35), spacing: 0)
-    ]
     
     var body: some View {
-        Text("Triplet View")
-            .padding()
-        LazyHGrid(
-            rows: rows,
-            alignment: .center,
-            spacing: 0
-        ) {
-            ForEach(data, id: \.self) { item in
-                HStack {
-                    Spacer()
-                    VStack(spacing: 0) {
-                        Spacer()
-                        Text(item)
-                            .border(Color.green, width: 1)
-                        Spacer()
-                    }
-                    Spacer()
-                }
-                .border(Color.blue, width: 1)
+        Text("Keep trying!!")
+        GeometryReader { geometry in
+            
+            let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
+            
+            VStack {
+                TripletView2(containerLimit: shorterLength)
+                    .frame(height: shorterLength * 0.33)
+                    .border(Color.red, width: 1)
+                TripletView2(containerLimit: shorterLength)
+                    .frame(height: shorterLength * 0.34)
+                    .border(Color.red, width: 1)
+                TripletView2(containerLimit: shorterLength)
+                    .frame(height: shorterLength * 0.33)
+                    .border(Color.red, width: 1)
+            }
+            
+            VStack {
+                Text("width: \(geometry.size.width)")
+                Text("height: \(geometry.size.height)")
             }
         }
-        .border(Color.yellow, width: 3)
         
     }
 }
@@ -54,6 +39,67 @@ struct ContentView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+    }
+}
+
+
+    
+struct TripletView2: View {
+    
+    let containerLimit: CGFloat
+    
+    var body: some View {
+        GeometryReader { geometry in
+            
+            //let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
+            
+            HStack(spacing: 0) {
+                Text("1")
+                    .font(.largeTitle)
+                    .foregroundColor(.black)
+                    .frame(width: containerLimit * 0.33, height: containerLimit * 0.33)
+                    .background(Color.yellow)
+                    .border(Color.black, width: 1)
+                Text("2")
+                    .font(.largeTitle)
+                    .foregroundColor(.black)
+                    .frame(width: containerLimit * 0.34, height: containerLimit * 0.33)
+                    .background(Color.orange)
+                    .border(Color.black, width: 1)
+                Text("3")
+                    .font(.largeTitle)
+                    .foregroundColor(.black)
+                    .frame(width:  containerLimit * 0.33, height: containerLimit * 0.33)
+                    .background(Color.green)
+                    .border(Color.black, width: 1)
+            }
+            
+            VStack {
+                Text("width: \(geometry.size.width)")
+                Text("height: \(geometry.size.height)")
+            }
+        }
+    }
+}
+
+struct NonetView2: View {
+    let columnData = (1...3).map { "c\($0)" }
+    let rowData = (1...3).map { "r\($0)" }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(columnData, id: \.self) { item in
+                VStack(spacing: 0) {
+                    ForEach(rowData, id: \.self) { item in
+                        Text("2")
+                            //.padding()
+                        Divider()
+                    }
+                }
+                Divider()
+            }
+        }
+        .border(Color.yellow, width: 2)
     }
 }
 

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -15,21 +15,31 @@ struct ContentView: View {
             
             let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
             
-            VStack (spacing: 0) {
-                TripletView2(containerLimit: shorterLength)
-                    .frame(height: shorterLength * 0.33)
-                    .border(Color.red, width: 4)
-                TripletView2(containerLimit: shorterLength)
-                    .frame(height: shorterLength * 0.34)
-                    .border(Color.red, width: 4)
-                TripletView2(containerLimit: shorterLength)
-                    .frame(height: shorterLength * 0.33)
-                    .border(Color.red, width: 4)
-            }
-            
-            VStack {
-                Text("width: \(geometry.size.width)")
-                Text("height: \(geometry.size.height)")
+            HStack {
+                VStack(spacing: 0)  {
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                }
+                VStack(spacing: 0)  {
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                }
+                VStack(spacing: 0)  {
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                    NonetView3(containerLimit: shorterLength * 0.33)
+                        .frame(height: shorterLength * 0.33)
+                }
             }
         }
         
@@ -42,9 +52,7 @@ struct ContentView_Previews: PreviewProvider {
     }
 }
 
-
-    
-struct TripletView2: View {
+struct NonetView3: View {
     
     let containerLimit: CGFloat
     
@@ -52,6 +60,26 @@ struct TripletView2: View {
         GeometryReader { geometry in
             
             //let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
+            
+            VStack(spacing: 0) {
+                TripletView2(containerLimit: containerLimit)
+                    .frame(height: containerLimit * 0.33)
+                TripletView2(containerLimit: containerLimit)
+                    .frame(height: containerLimit * 0.34)
+                TripletView2(containerLimit: containerLimit)
+                    .frame(height: containerLimit * 0.33)
+            }
+            .border(Color.red, width: 4)
+        }
+    }
+}
+
+    
+struct TripletView2: View {
+    
+    let containerLimit: CGFloat
+    
+    var body: some View {
             
             HStack(spacing: 0) {
                 Text("1")
@@ -73,12 +101,6 @@ struct TripletView2: View {
                     .background(Color.green)
                     .border(Color.black, width: 1)
             }
-            
-            VStack {
-                Text("width: \(geometry.size.width)")
-                Text("height: \(geometry.size.height)")
-            }
-        }
     }
 }
 

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -43,13 +43,23 @@ struct ContentView: View {
 //                }
 //            }
         }
-        
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        VStack {
+            Text("This should show a nonet in a containing view that is wider than it is tall. So the size of the nonent will be limited by the height dimension of the containing view. The nonet should fill the height but not the width (since the nonet should always be a square.")
+            NonetView()
+                .frame(width: 300, height: 100)
+                .background(Color.blue)
+        }
+        VStack {
+            Text("This should show a nonet in a containing view that is taller than it is wide. So the size of the nonent will be limited by the width dimension of the containing view. The nonet should fill the width but not the height (since the nonet should always be a square.")
+            NonetView()
+                .frame(width: 100, height: 300)
+                .background(Color.blue)
+        }
     }
 }
 

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -40,77 +40,9 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        VStack {
-            Text("This should show a nonet in a containing view that is wider than it is tall. So the size of the nonent will be limited by the height dimension of the containing view. The nonet should fill the height but not the width (since the nonet should always be a square.")
-            NonetView()
-                .frame(width: 300, height: 100)
-                .background(Color.blue)
-        }
-        VStack {
-            Text("This should show a nonet in a containing view that is taller than it is wide. So the size of the nonent will be limited by the width dimension of the containing view. The nonet should fill the width but not the height (since the nonet should always be a square.")
-            NonetView()
-                .frame(width: 100, height: 300)
-                .background(Color.blue)
-        }
-        VStack {
-            Text("This is not what I want")
-            VStack(spacing: 0) {
-                NonetView()
-                    .border(Color.blue, width: 2)
-                NonetView()
-                NonetView()
-            }.frame(width: 100)
-        }
+        ContentView()
     }
 }
 
-/*
- A NonetView is a square made up of 9 squares in a 3 x 3 formation. It fills it's containing view, but does not overflow it ever.
- */
-struct NonetView: View {
-    
-    var body: some View {
-        GeometryReader { geometry in
-            
-            VStack(spacing: 0) {
-                TripletView(containerSize: geometry.size)
-                TripletView(containerSize: geometry.size)
-                TripletView(containerSize: geometry.size)
-            }
-            .border(Color.black, width: 2)
-        }
-    }
-}
 
-/*
- A TripletView is a 1 x 3 grid. It is a single row of 3 squares. It will expand to fill it's containing view, but will always
- be comprised of 3 squares, not rectangles.
- */
-struct TripletView: View {
-    
-    let containerSize: CGSize
-    
-    var body: some View {
-        
-        let containerLimit = containerSize.width < containerSize.height ? containerSize.width : containerSize.height
-        let sqSide: CGFloat = containerLimit / 3
-            
-        HStack(spacing: 0) {
-            Text(" ")
-                .font(.largeTitle)
-                .foregroundColor(.black)
-                .frame(width: sqSide, height: sqSide)
-                .border(Color.black, width: 1)
-            Text(" ")
-                .font(.largeTitle)
-                .foregroundColor(.black)
-                .frame(width: sqSide, height: sqSide)
-                .border(Color.black, width: 1)
-            Text(" ")
-                .font(.largeTitle)
-                .foregroundColor(.black)
-                .frame(width: sqSide, height: sqSide)
-                .border(Color.black, width: 1)
-        }
-    }
-}
+

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -9,10 +9,28 @@ import SwiftUI
 
 struct ContentView: View {
     
+    let data = (1...9).map { "Item \($0)" }
+    
+    let columns = [
+        GridItem(.flexible(), spacing: 0),
+        GridItem(.flexible(), spacing: 0),
+        GridItem(.flexible(), spacing: 0)
+    ]
+    
     var body: some View {
         Text("Hello, world!")
             .padding()
-        NonetView()
+        LazyVGrid(
+            columns: columns,
+            alignment: .center,
+            spacing: 0
+        ) {
+            ForEach(data, id: \.self) { item in
+                NonetView()
+                .border(Color.yellow, width: 1)
+            }
+        }
+        .border(Color.orange, width: 3)
     }
 }
 
@@ -23,7 +41,7 @@ struct ContentView_Previews: PreviewProvider {
 }
 
 struct NonetView: View {
-    let data = (1...9).map { "Item \($0)" }
+    let data = (1...9).map { "\($0)" }
     
     let columns = [
         GridItem(.flexible(), spacing: 0),

--- a/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/ContentView.swift
@@ -15,16 +15,16 @@ struct ContentView: View {
             
             let shorterLength = (geometry.size.width < geometry.size.height) ? geometry.size.width : geometry.size.height
             
-            VStack {
+            VStack (spacing: 0) {
                 TripletView2(containerLimit: shorterLength)
                     .frame(height: shorterLength * 0.33)
-                    .border(Color.red, width: 1)
+                    .border(Color.red, width: 4)
                 TripletView2(containerLimit: shorterLength)
                     .frame(height: shorterLength * 0.34)
-                    .border(Color.red, width: 1)
+                    .border(Color.red, width: 4)
                 TripletView2(containerLimit: shorterLength)
                     .frame(height: shorterLength * 0.33)
-                    .border(Color.red, width: 1)
+                    .border(Color.red, width: 4)
             }
             
             VStack {

--- a/ElementarySudokuSolver/ElementarySudokuSolver/NonetView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/NonetView.swift
@@ -1,0 +1,52 @@
+//
+//  NonetView.swift
+//  ElementarySudokuSolver
+//
+//  Created by Erin Hamalainen on 12/06/2021.
+//
+
+import SwiftUI
+
+/*
+ A NonetView is a square made up of 9 squares in a 3 x 3 formation. It fills it's containing view, but does not overflow it ever.
+ */
+struct NonetView: View {
+    
+    var body: some View {
+        GeometryReader { geometry in
+            
+            VStack(spacing: 0) {
+                TripletView(containerSize: geometry.size)
+                TripletView(containerSize: geometry.size)
+                TripletView(containerSize: geometry.size)
+            }
+            .border(Color.black, width: 2)
+        }
+    }
+}
+
+struct NonetView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            Text("This should show a nonet in a containing view that is wider than it is tall. So the size of the nonent will be limited by the height dimension of the containing view. The nonet should fill the height but not the width (since the nonet should always be a square.")
+            NonetView()
+                .frame(width: 300, height: 100)
+                .background(Color.blue)
+        }
+        VStack {
+            Text("This should show a nonet in a containing view that is taller than it is wide. So the size of the nonent will be limited by the width dimension of the containing view. The nonet should fill the width but not the height (since the nonet should always be a square.")
+            NonetView()
+                .frame(width: 100, height: 300)
+                .background(Color.blue)
+        }
+        VStack {
+            Text("This is not what I want")
+            VStack(spacing: 0) {
+                NonetView()
+                    .border(Color.blue, width: 2)
+                NonetView()
+                NonetView()
+            }.frame(width: 100)
+        }
+    }
+}

--- a/ElementarySudokuSolver/ElementarySudokuSolver/TripletView.swift
+++ b/ElementarySudokuSolver/ElementarySudokuSolver/TripletView.swift
@@ -1,0 +1,47 @@
+//
+//  TripletView.swift
+//  ElementarySudokuSolver
+//
+//  Created by Erin Hamalainen on 12/06/2021.
+//
+
+import SwiftUI
+
+/*
+ A TripletView is a 1 x 3 grid. It is a single row of 3 squares. It will expand to fill it's containing view, but will always
+ be comprised of 3 squares, not rectangles.
+ */
+struct TripletView: View {
+    
+    let containerSize: CGSize
+    
+    var body: some View {
+        
+        let containerLimit = containerSize.width < containerSize.height ? containerSize.width : containerSize.height
+        let sqSide: CGFloat = containerLimit / 3
+            
+        HStack(spacing: 0) {
+            Text(" ")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .border(Color.black, width: 1)
+            Text(" ")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .border(Color.black, width: 1)
+            Text(" ")
+                .font(.largeTitle)
+                .foregroundColor(.black)
+                .frame(width: sqSide, height: sqSide)
+                .border(Color.black, width: 1)
+        }
+    }
+}
+
+struct TripletView_Previews: PreviewProvider {
+    static var previews: some View {
+        TripletView(containerSize: CGSize(width: 100, height: 100))
+    }
+}


### PR DESCRIPTION
### Description
When the user launches the app, they should see an empty sudoku puzzle

<img width="300" alt="Screenshot 2021-06-12 at 14 22 29" src="https://user-images.githubusercontent.com/47641432/121784034-7a7f3280-cba9-11eb-90e6-1bfa7d5b2f01.png">

### Links
Issue: https://github.com/tricerintops/ElementarySudokuSolver/issues/1

### QA instructions
Test on several form factors
- Make sure to at least test on the smallest form factor we support (iPod Touch 7th generation or original iPhone SE)
- And the largest phone - iPhone 12 Pro Max
- Please also check on iPad!!!

Test on different orientations
- Please check portrait AND landscape for all form factors you test!!

What to look for:
- The puzzle should be centered both vertically and horizontally.
- It should almost fill the screen